### PR TITLE
Add Makefile for Linux builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+umka
+libumka.so

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.POSIX:
+
+SRC = src
+CFLAGS = -fPIC -O3 -Wall -Wno-format-security
+LDFLAGS = -static-libgcc
+
+BIN_OBJ = src/umka.o
+LIB_OBJ = src/umka_api.o src/umka_common.o src/umka_compiler.o src/umka_const.o src/umka_decl.o src/umka_expr.o src/umka_gen.o src/umka_ident.o src/umka_lexer.o src/umka_runtime.o src/umka_stmt.o src/umka_types.o src/umka_vm.o
+
+.PHONY: all clean
+all: umka libumka.so
+clean:
+	rm -f umka libumka.so
+	rm -f src/*.o
+
+umka: $(BIN_OBJ) $(LIB_OBJ)
+	$(CC) $(LDFLAGS) -o $@ $^ -lm
+
+libumka.so: $(LIB_OBJ)
+	$(CC) $(LDFLAGS) -shared -fPIC -o libumka.so $^ -lm
+
+src/%.o: src/%.c


### PR DESCRIPTION
The existing choice for building is either a shell script that rebuilds the entire project every time or a CodeBlocks project. This PR adds a Makefile, for those who would prefer to work on Umka in a different editor.

I note there was a PR to add CMake (#5) that did not get merged due to CMake being an external dependency. Personally, I would not consider POSIX make an external dependency, as any platform that has a compliant C99 compiler installed will almost certainly have a compliant make as well.