### PR TITLE
Using equivalence hypotheses for type equivalence checks

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -342,9 +342,7 @@ Two types are *equivalent* if
 * They are array types and have equal length and equivalent item types
 * They are dynamic array types and have equivalent item types
 * They are structure or interface types and have equal number of fields, equal field names and equivalent field types
-* They are function types, which are both either methods or non-methods, and have equal number of parameters, equal parameter names, equivalent parameter types, equal parameter default values (excluding the receiver parameter) and equivalent result type
-
-If type equivalence cannot be proven in a sufficiently large (implementation-dependent) number of recursive checks, the types are considered non-equivalent.  
+* They are function types, which are both either methods or non-methods, and have equal number of parameters, equal parameter names, equivalent parameter types, equal parameter default values (excluding the receiver parameter) and equivalent result type.
 
 Two types are *compatible* if
 

--- a/src/umka_types.c
+++ b/src/umka_types.c
@@ -222,8 +222,7 @@ typedef struct tagTypeEquivalenceHypothesis
 static bool typeEquivalentRecursive(Type *left, Type *right, TypeEquivalenceHypothesis *hypotheses)
 {
     TypeEquivalenceHypothesis *prev_hypo = hypotheses;
-    while (prev_hypo != NULL &&
-           !(prev_hypo->left == left && prev_hypo->right == right))
+    while (prev_hypo && !(prev_hypo->left == left && prev_hypo->right == right))
         prev_hypo = prev_hypo->next;
 
     if (prev_hypo)

--- a/src/umka_types.c
+++ b/src/umka_types.c
@@ -211,10 +211,25 @@ bool typeGarbageCollected(Type *type)
 }
 
 
-static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
+typedef struct tagTypeEquivalenceHypothesis
 {
-    if (depth <= 0)
-        return false;
+    Type *left;
+    Type *right;
+    struct tagTypeEquivalenceHypothesis *next;
+} TypeEquivalenceHypothesis;
+
+
+static bool typeEquivalentRecursive(Type *left, Type *right, TypeEquivalenceHypothesis *hypotheses)
+{
+    TypeEquivalenceHypothesis *prev_hypo = hypotheses;
+    while (prev_hypo != NULL &&
+           !(prev_hypo->left == left && prev_hypo->right == right))
+        prev_hypo = prev_hypo->next;
+
+    if (prev_hypo)
+        return true;
+
+    TypeEquivalenceHypothesis cur_hypothesis = { left, right, hypotheses };
 
     if (left == right)
         return true;
@@ -223,7 +238,7 @@ static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
     {
         // Pointers
         if (left->kind == TYPE_PTR)
-            return typeEquivalentRecursive(left->base, right->base, depth - 1) && left->weak == right->weak;
+            return typeEquivalentRecursive(left->base, right->base, &cur_hypothesis) && left->weak == right->weak;
 
         // Arrays
         else if (left->kind == TYPE_ARRAY)
@@ -232,12 +247,12 @@ static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
             if (left->numItems != right->numItems)
                 return false;
 
-            return typeEquivalentRecursive(left->base, right->base, depth - 1);
+            return typeEquivalentRecursive(left->base, right->base, &cur_hypothesis);
         }
 
         // Dynamic arrays
         else if (left->kind == TYPE_DYNARRAY)
-            return typeEquivalentRecursive(left->base, right->base, depth - 1);
+            return typeEquivalentRecursive(left->base, right->base, &cur_hypothesis);
 
         // Strings
         else if (left->kind == TYPE_STR)
@@ -258,7 +273,7 @@ static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
                     return false;
 
                 // Type
-                if (!typeEquivalentRecursive(left->field[i]->type, right->field[i]->type, depth - 1))
+                if (!typeEquivalentRecursive(left->field[i]->type, right->field[i]->type, &cur_hypothesis))
                     return false;
             }
             return true;
@@ -285,7 +300,7 @@ static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
                     return false;
 
                 // Type
-                if (!typeEquivalentRecursive(left->sig.param[i]->type, right->sig.param[i]->type, depth - 1))
+                if (!typeEquivalentRecursive(left->sig.param[i]->type, right->sig.param[i]->type, &cur_hypothesis))
                     return false;
 
                 // Default value
@@ -294,7 +309,7 @@ static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
             }
 
             // Result type
-            if (!typeEquivalentRecursive(left->sig.resultType, right->sig.resultType, depth - 1))
+            if (!typeEquivalentRecursive(left->sig.resultType, right->sig.resultType, &cur_hypothesis))
                 return false;
 
             return true;
@@ -310,8 +325,7 @@ static bool typeEquivalentRecursive(Type *left, Type *right, int depth)
 
 bool typeEquivalent(Type *left, Type *right)
 {
-    enum {MAX_TYPE_EQUIVALENCE_DEPTH = 500};
-    return typeEquivalentRecursive(left, right, MAX_TYPE_EQUIVALENCE_DEPTH);
+    return typeEquivalentRecursive(left, right, NULL);
 }
 
 

--- a/tests/all.um
+++ b/tests/all.um
@@ -8,6 +8,7 @@ import (
     "interfaces3.um"
     "multret.um"
     "tour.um"
+    "type_equivalence.um"
 )
 
 fn main() {
@@ -20,4 +21,5 @@ fn main() {
     printf("\n\n>>> Interfaces - 3\n\n");       interfaces3.test()
     printf("\n\n>>> Multiple returns\n\n");     multret.test()
     printf("\n\n>>> Language tour\n\n");        tour.test()
+    printf("\n\n>>> Type equivalence\n\n");     type_equivalence.test()
 }

--- a/tests/type_equivalence.um
+++ b/tests/type_equivalence.um
@@ -1,0 +1,42 @@
+type (
+    P1 = ^S1
+    S1 = struct {
+      x: int
+      next: P1
+    }
+)
+
+type (
+    P2 = ^S2
+    S2 = struct {
+      x: int
+      next: P2
+    }
+)
+
+type (
+    P3 = ^S3
+    P4 = ^S4
+
+    S3 = struct {
+      x: int
+      next: P4
+    }
+
+    S4 = struct {
+      x: int
+      next: P3
+    }
+)
+
+fn test*() {
+    var p1 : P1
+    var p3 : P3
+    var p4 : P4
+
+    p1 = new(S2)
+    p3 = p1
+    p4 = p1
+
+    printf("    ...passed\n");
+}


### PR DESCRIPTION
Structural type equivalence is fixed. There is a working test:
```
type (
    P1 = ^S1
    S1 = struct {
      x: int
      next: P1
    }
)

type (
    P2 = ^S2
    S2 = struct {
      x: int
      next: P2
    }
)

type (
    P3 = ^S3
    P4 = ^S4

    S3 = struct {
      x: int
      next: P4
    }

    S4 = struct {
      x: int
      next: P3
    }
)

fn test*() {
    var p1 : P1
    var p3 : P3
    var p4 : P4

    p1 = new(S2)
    p3 = p1
    p4 = p1

    printf("    ...passed\n");
}
```