### PR TITLE
Makefile: for mingw s/.so/.dll/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifeq ($(shortplatform), MINGW64_NT)
   LPATH = PATH
   STATIC_LDFLAGS = -rs 
   DYNAMIC_LDFLAGS = -shared -lm
-  DYNAMIC_LIB = $(buildpath)/libumka.so
+  DYNAMIC_LIB = $(buildpath)/libumka.dll
   EXECUTABLE_DEPS = -lm
   RANLIB = ar
 endif


### PR DESCRIPTION
When building libumka with mingw it uses '.so' extension for the dynamic library instead of '.dll'.

This was probably a copy-paste mistake.
