### PR TITLE
Add missing const.

### DIFF
--- a/src/umka_types.c
+++ b/src/umka_types.c
@@ -9,7 +9,7 @@
 #include "umka_ident.h"
 
 
-static char *spelling [] =
+static const char *spelling [] =
 {
     "none",
     "forward",


### PR DESCRIPTION
```tcc``` was not happy about it.
