### PR TITLE
add hashmap to string method

### DIFF
--- a/import/map.um
+++ b/import/map.um
@@ -99,3 +99,39 @@ fn (m: ^Map) rehash() {
   
     m^ = n
 }
+
+
+fn trimTrailingSpaces(inp: str): str {
+	out := make([]char, len(inp))
+
+	for i, c in inp {
+		if c == ' ' {
+			break
+		}
+
+		out[i] = c
+	}
+
+	return str(out)
+}
+
+
+fn (m: ^Map) toStr(): str {
+	out := "{ "
+
+	for i, bucket in m^ {
+		if len(bucket) == 0 {
+			continue
+		}
+
+		for j, item in bucket {
+			out += item.key + ": " + trimTrailingSpaces(repr(item.val)) + ", "
+		}
+	}
+
+	if len(out) > 2 {
+		out = slice(out, 0, len(out) - 2)
+	}
+
+	return out + " }"
+}

--- a/tests/maps.um
+++ b/tests/maps.um
@@ -30,6 +30,8 @@ fn test*() {
         error("Test failed")
     }
 
+		printf("%s\n", populations.toStr())
+
     printf("Population of Russia was %.2f million. Now it is %.2f million\n", russia2019, russia2020)
 }
 


### PR DESCRIPTION
Creates a more readable string than `repr` does.

I'm unsure about the naming case. What should be used in umka?