### PR TITLE
Update Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.o
-build/
-obj/
+*build/
+*obj/
 src/umka_runtime_src.h

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,20 @@
-PLATFORM      = $(shell uname -s)
-SHORTPLATFORM = $(shell (X=`uname -s`; echo $${X:0:10}))
+.PHONY: all clean
+
+PLATFORM ?= $(shell uname -s)
 
 BUILD_PATH ?= build
+OBJ_PATH   ?= obj
 
 # platform specific settings:
 ifeq ($(PLATFORM), Linux)
 	LDFLAGS = -lm -ldl
 	RANLIB = ar -crs
-else
-ifeq ($(PLATFORM), Darwin)
+else ifeq ($(PLATFORM), Darwin)
 	LDFLAGS =
 	RANLIB = libtool -static -o
-else
-ifeq ($(SHORTPLATFORM), MINGW64_NT)
+else ifneq ($(findstring MINGW64_NT,$(PLATFORM)),)
 	LDFLAGS = -lm
 	RANLIB = ar -crs
-endif
-endif
 endif
 
 # identical for all platforms:
@@ -24,51 +22,49 @@ UMKA_LIB_STATIC  = $(BUILD_PATH)/libumka.a
 UMKA_LIB_DYNAMIC = $(BUILD_PATH)/libumka.so
 UMKA_EXE = $(BUILD_PATH)/umka
 
-CFLAGS = -s -fPIC -O3 -Wall -Wno-format-security -fno-strict-aliasing -DUMKA_EXT_LIBS
+CFLAGS = -s -fPIC -O3 -Wall -Wno-format-security -fno-strict-aliasing -DUMKA_EXT_LIBS -Iimport_embed
 STATIC_CFLAGS  = $(CFLAGS) -DUMKA_STATIC
 DYNAMIC_CFLAGS = $(CFLAGS) -DUMKA_BUILD  -shared -fvisibility=hidden
 
 SRCS = $(filter-out src/umka.c,$(wildcard src/*.c))
-OBJS_STATIC    = $(sort $(SRCS:src/%.c=obj/%_static.o))
-OBJS_DYNAMIC   = $(sort $(SRCS:src/%.c=obj/%_dynamic.o))
+OBJS_STATIC    = $(sort $(SRCS:src/%.c=$(OBJ_PATH)/%_static.o))
+OBJS_DYNAMIC   = $(sort $(SRCS:src/%.c=$(OBJ_PATH)/%_dynamic.o))
 
 APIS = src/umka_api.h
-OBJS_EXE = obj/umka_static.o
+OBJS_EXE = $(OBJ_PATH)/umka_static.o
 
-.PHONY: all path clean
-all: path $(UMKA_EXE) $(UMKA_LIB_STATIC) $(UMKA_LIB_DYNAMIC)
-
-static:  path $(UMKA_LIB_STATIC)
-dynamic: path $(UMKA_LIB_DYNAMIC)
-exe:     path $(UMKA_EXE)
+all:     $(UMKA_EXE) $(UMKA_LIB_STATIC) $(UMKA_LIB_DYNAMIC)
+static:  $(UMKA_LIB_STATIC)
+dynamic: $(UMKA_LIB_DYNAMIC)
+exe:     $(UMKA_EXE)
 
 clean:
-	$(RM) $(BUILD_PATH) obj -r
+	$(RM) $(BUILD_PATH) $(OBJ_PATH) -r
 	$(RM) src/umka_runtime_src.h
-
-path:
-	@mkdir -p -- obj $(BUILD_PATH)/include
-	@cp import_embed/umka_runtime_src.h src/
 
 $(UMKA_LIB_STATIC): $(OBJS_STATIC)
 	@echo AR $@
+	@mkdir -p -- $(BUILD_PATH)/include/
 	@$(RANLIB) $(UMKA_LIB_STATIC) $^
 	@cp $(APIS) $(BUILD_PATH)/include/
 
 $(UMKA_LIB_DYNAMIC): $(OBJS_DYNAMIC)
 	@echo LD $@
+	@mkdir -p -- $(BUILD_PATH)/include/
 	@$(CC) $(DYNAMIC_CFLAGS) -o $(UMKA_LIB_DYNAMIC) $^ $(LDFLAGS)
 	@cp $(APIS) $(BUILD_PATH)/include/
 
 $(UMKA_EXE): $(OBJS_EXE) $(UMKA_LIB_STATIC)
 	@echo LD $@
+	@mkdir -p -- $(dir $@)
 	@$(CC) $(STATIC_CFLAGS) -o $(UMKA_EXE) $^ $(LDFLAGS)
 
-obj/%_static.o: src/%.c
+$(OBJ_PATH)/%_static.o: src/%.c
 	@echo CC $@
+	@mkdir -p -- $(dir $@)
 	@$(CC) $(STATIC_CFLAGS) -o $@ -c $^
 
-obj/%_dynamic.o: src/%.c
+$(OBJ_PATH)/%_dynamic.o: src/%.c
 	@echo CC $@
+	@mkdir -p -- $(dir $@)
 	@$(CC) $(DYNAMIC_CFLAGS) -o $@ -c $^
-


### PR DESCRIPTION
It would be convenient for me to be able to change the `obj` directory when building. So I'm creating this pull request.

Other minor changes:
- the `path` rule removed, the `umka_runtime_src.h` is now included with a `-I` flag in compiler args and directories are created by individual rules that need them.
- the `SHORTPLATFORM` variable removed and `MINGW64_NT` is now tested for using the `findstring` function