### PR TITLE
Fix optimizer bug with invalid index when indexing via global

### DIFF
--- a/src/umka_gen.c
+++ b/src/umka_gen.c
@@ -156,7 +156,10 @@ static bool optimizeGetArrayPtr(CodeGen *gen, int itemSize, int len)
     // Optimization: PUSH + GET_ARRAY_PTR -> GET_FIELD_PTR
     if (prev && prev->opcode == OP_PUSH && len >= 0)
     {
-        int index = prev->operand.intVal;
+        if (prev->tokKind != TOK_INTNUMBER)
+                return false;
+
+        int index = prev->operand.intVal; 
 
         if (index < 0 || index > len - 1)
             gen->error->handler(gen->error->context, "Index %d is out of range 0...%d", index, len - 1);
@@ -165,7 +168,6 @@ static bool optimizeGetArrayPtr(CodeGen *gen, int itemSize, int len)
         genGetFieldPtr(gen, itemSize * index);
         return true;
     }
-
     return false;
 }
 


### PR DESCRIPTION
This fixes #117 
apparently it tried to take intVal of an identifier, adding TOK_INTNUMBER check will make sure it's optimizing literals