### PR TITLE
VM main loop 20% speedup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ UMKA_LIB_STATIC  = $(BUILD_PATH)/libumka.a
 UMKA_LIB_DYNAMIC = $(BUILD_PATH)/libumka.so
 UMKA_EXE = $(BUILD_PATH)/umka
 
-CFLAGS = -s -fPIC -O3 -Wall -Wno-format-security -malign-double -fno-strict-aliasing -DUMKA_EXT_LIBS -Iimport_embed
+CFLAGS = -s -fPIC -O3 -Wall -Wno-format-security -malign-double -fno-strict-aliasing -DUMKA_EXT_LIBS -Iimport_embed -finline-limit=5000
 STATIC_CFLAGS  = $(CFLAGS) -DUMKA_STATIC
 DYNAMIC_CFLAGS = $(CFLAGS) -DUMKA_BUILD  -shared -fvisibility=hidden
 

--- a/src/umka_vm.c
+++ b/src/umka_vm.c
@@ -2117,8 +2117,14 @@ static void vmLoop(VM *vm)
     HeapPages *pages = &vm->pages;
     Error *error = vm->error;
 
+#ifdef __GNUC__
+#  define unlikely(EXPR) __builtin_expect(EXPR, 0)
+#else
+#  define unlikely(EXPR) (EXPR)
+#endif
+
 #define OVERFLOW_CHECK \
-    if (__builtin_expect((fiber->top - fiber->stack < VM_MIN_FREE_STACK),0)) \
+    if (unlikely(fiber->top - fiber->stack < VM_MIN_FREE_STACK)) \
     { error->handlerRuntime(error->context, "Stack overflow"); }
 
 #define JUMP \
@@ -2206,7 +2212,7 @@ CALL_BUILTIN:
 		       }
 RETURN:
 		       {
-			       if (__builtin_expect((fiber->top->intVal == 0), 0))
+			       if (unlikely(fiber->top->intVal == 0))
 				       return;
 
 			       Fiber *newFiber = NULL;
@@ -2215,7 +2221,7 @@ RETURN:
 			       if (newFiber)
 				       fiber = vm->fiber = newFiber;
 
-			       if (__builtin_expect((!fiber->alive),0))
+			       if (unlikely(!fiber->alive))
 				       return;
 
 			       JUMP;


### PR DESCRIPTION
Hello,

I swapped the while+switch combination in the VM's main loop for computed gotos.

The idea behind this is that instead of jumping to the start of the loop, to a case and back up to the start, we jump between individual cases.

This branching elimination results in 20% speedup on the matrices benchmark.

Unfortunately, I don't think one can implement a 'default' case for the gotos, because of this I had to remove this check and corrupted instructions now can corrupt the entire interpreter.

The big bottleneck now seems to be the overflow check that has to be done before each jump. Removing this would result in another 10% down on the matrices but it might not be a good idea to remove this.