### PR TITLE
Add UmBox builds and CI

### DIFF
--- a/.github/workflows/umbox.yml
+++ b/.github/workflows/umbox.yml
@@ -1,0 +1,18 @@
+name: UmBox upload
+
+on:
+  push:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install -y mingw-w64
+      - uses: marekmaskarinec/umbox@master
+        with:
+          secret: ${{ secrets.UMBOX }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *build/
 *obj/
 src/umka_runtime_src.h
+box.tar

--- a/box.json
+++ b/box.json
@@ -1,0 +1,20 @@
+{
+    "name": "umka",
+    "version": "v1.4.0",
+    "author": "Vasiliy Tereshkov",
+    "license": "BSD-2",
+    "description": "The Umka Programming language",
+    "readme": "README.md",
+    "link": "https://github.com/vtereshkov/umka-lang",
+    "dependencies": [],
+    "include": [
+			"umka.exe",
+			"umka",
+			"libumka.so",
+			"libumka.dll",
+			"umka_api.h"
+		],
+		"pre_build": "sh umbox_pre_build.sh",
+		"post_build": "sh umbox_post_build.sh",
+		"run": "make"
+}

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -17,6 +17,7 @@ gcc -s umka.o -o umka -static-libgcc -L$PWD -lm -lumka -Wl,-rpath,'$ORIGIN' &&
 ar rcs libumka_static.a *.o &&
 
 rm -f *.o &&
+rm -f *.a &&
 
 cd .. &&
 

--- a/build_linux_mingw.sh
+++ b/build_linux_mingw.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+
+gccwflags="-Wall -Wno-format-security"
+gccflags="-s -fPIC -O3 -malign-double -fno-strict-aliasing -fvisibility=hidden -DUMKA_BUILD -DUMKA_EXT_LIBS $gccwflags"
+sourcefiles="umka_api.c umka_common.c umka_compiler.c umka_const.c   umka_decl.c umka_expr.c
+             umka_gen.c umka_ident.c  umka_lexer.c    umka_runtime.c umka_stmt.c umka_types.c umka_vm.c"
+
+rm umka_windows_mingw -rf # remove previous build
+
+cd src
+
+rm -f *.o
+rm -f *.a
+
+x86_64-w64-mingw32-gcc $gccflags -c $sourcefiles
+x86_64-w64-mingw32-gcc -s -shared -fPIC -static-libgcc *.o -o libumka.dll -lm
+
+x86_64-w64-mingw32-gcc $gccflags -c umka.c
+x86_64-w64-mingw32-gcc -s umka.o -o umka.exe -static-libgcc -lm -L. -lumka -Wl,-rpath,'$ORIGIN'
+ar rcs libumka_static.a *.o
+
+rm -f *.o
+rm -f *.a
+
+cd ..
+
+mkdir umka_windows_mingw/examples/3dcam -p
+mkdir umka_windows_mingw/examples/fractal -p
+mkdir umka_windows_mingw/examples/lisp -p
+mkdir umka_windows_mingw/examples/raytracer -p
+mkdir umka_windows_mingw/doc
+
+mv src/libumka* src/umka.exe umka_windows_mingw/
+cp src/umka_api.h Umka.sublime-syntax LICENSE umka_windows_mingw/
+
+cp examples/* umka_windows_mingw/examples -r
+cp doc/* umka_windows_mingw/doc
+
+echo Build successful

--- a/umbox_post_build.sh
+++ b/umbox_post_build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+rm -rf umka_linux umka_windows_mingw
+rm -f umka_api.h libumka.so libumka.dll umka umka.exe

--- a/umbox_pre_build.sh
+++ b/umbox_pre_build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+./build_linux.sh
+./build_linux_mingw.sh
+cp umka_linux/umka .
+cp umka_linux/libumka.so .
+cp umka_windows_mingw/umka.exe .
+cp umka_windows_mingw/libumka.dll .
+cp src/umka_api.h .


### PR DESCRIPTION
Adds a `box.json` for Umka as well as a CI script, which automatically updates the upstream box. I also added a cross compilation script, which is needed for this task. Fixes issue #319.

Example run:
https://github.com/marekmaskarinec/umka-lang/actions/runs/8376627290/job/22936744052

After merging, you will need to add the appropriate secret to the repo.