### PR TITLE
Fix umbox.yml ubuntu version

### DIFF
--- a/.github/workflows/umbox.yml
+++ b/.github/workflows/umbox.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
All boxes should be built on ubuntu 20.04 to prevent incompatibilities.