### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ dynamic: $(UMKA_LIB_DYNAMIC)
 exe:     $(UMKA_EXE)
 
 clean:
-	$(RM) $(BUILD_PATH) $(OBJ_PATH) -r
+	$(RM) -r $(BUILD_PATH) $(OBJ_PATH)
 
 install: all
 	@echo "Installing to the following directories:"


### PR DESCRIPTION
Moved `-r` switch before the arguments to the `rm` command so `make clean` removes the directories on MacOS

Before this, the obj and build folders weren't being cleaned fully so the resultant DLLs were not working correctly.