### PR TITLE
Update build_darwin.sh use static lib

### DIFF
--- a/build_darwin.sh
+++ b/build_darwin.sh
@@ -17,7 +17,7 @@ clang -shared -fPIC *.o -o libumka.dylib -lm -ldl
 libtool -static -o libumka_static_darwin.a *.o
 
 clang $clangflags -c umka.c
-clang umka.o -o umka -L$PWD -lm -lumka -Wl,-rpath,'$ORIGIN'
+clang umka.o -o umka -L$PWD -lm -lumka_static_darwin -Wl,-rpath,'$ORIGIN'
 
 rm -f *.o
 


### PR DESCRIPTION
The currently used dynamic library (libumka.dylib), Each time you run the um file, you must copy libumka.dylib run it
So by changing to static compilation (-lumka_static_darwin), there is not need dynamic libraries run umscript now.