### PR TITLE
Add support for darwin builds

### DIFF
--- a/build_darwin.sh
+++ b/build_darwin.sh
@@ -13,7 +13,7 @@ rm -f *.o
 rm -f *.a
 
 clang $clangflags -c $sourcefiles
-clang -shared -fPIC *.o -o libumka.dylib -lm -ldl
+clang -dynamiclib -install_name @loader_path/libumka.dylib -fPIC *.o -o libumka.dylib -lm -ldl
 libtool -static -o libumka_static_darwin.a *.o
 
 clang $clangflags -c umka.c
@@ -38,3 +38,4 @@ cp doc/* umka_darwin/doc
 cp editors/* umka_darwin/editors
 
 echo Build finished
+

--- a/examples/3dcam/build_3dcam_darwin.sh
+++ b/examples/3dcam/build_3dcam_darwin.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cp ../../umka_darwin/libumka.dylib .
+cp ../../umka_darwin/umka_api.h .
+
+clang 3dcam.c -o 3dcam \
+    -L$PWD \
+    -lraylib -lumka \
+    -Wl,-rpath,'$ORIGIN'
+

--- a/test_darwin.sh
+++ b/test_darwin.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+cd tests
+
+cd lib
+./build_lib_darwin.sh
+cd ..
+
+../umka_darwin/umka -warn all.um > actual.log
+../umka_darwin/umka -warn compare.um actual.log expected.log
+cd .. 
+
+cd benchmarks
+../umka_darwin/umka -warn allbench.um > actual.log
+../umka_darwin/umka -warn ../tests/compare.um actual.log expected.log
+cd ..

--- a/tests/lib/build_lib_darwin.sh
+++ b/tests/lib/build_lib_darwin.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+clang -fPIC -O3 -c lib.c
+clang -dynamiclib -fPIC *.o -o lib.umi
+rm -f *.o
+


### PR DESCRIPTION
Tested both dynamic and statically linked executables with `./test_darwin.sh`. All examples are working too. Makefiles have warnings but I don't know how you'd like to refactor it. Other than that, all makefile targets work.

```
$ make
LD build/umka
ld: warning: -s is obsolete
CC obj/umka_api_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_common_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_compiler_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_const_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_decl_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_expr_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_gen_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_ident_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_lexer_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_runtime_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_stmt_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_types_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
CC obj/umka_vm_dynamic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
LD build/libumka.dylib
ld: warning: -s is obsolete
```