### PR TITLE
Sorted out dylib loading on macOS

### DIFF
--- a/build_darwin.sh
+++ b/build_darwin.sh
@@ -13,11 +13,11 @@ rm -f *.o
 rm -f *.a
 
 clang $clangflags -c $sourcefiles
-clang -shared -fPIC *.o -o libumka.dylib -lm -ldl
+clang -shared -fPIC *.o -o libumka.dylib -lm -ldl -Wl,-install_name,@rpath/libumka.dylib
 libtool -static -o libumka_static_darwin.a *.o
 
 clang $clangflags -c umka.c
-clang umka.o -o umka -L$PWD -lm -lumka -Wl,-rpath,'$ORIGIN'
+clang umka.o -o umka -L$PWD -lm -lumka -Wl,-rpath,@executable_path
 
 rm -f *.o
 


### PR DESCRIPTION
Updated the build so that `libumka.dylib` has a proper `install_name` (`@rpath/libumka.dylib`) and the executable carries an `rpath` that resolves relative to itself (`@loader_path`). This avoids dyld lookup issues when the binary ~is moved~ is ran out of the build directory. This is equivalent to the `$ORIGIN` mechanism, which is only applicable on Linux-based systems.
