### PR TITLE
Fix stack smashing during parse.

### DIFF
--- a/src/umka_common.c
+++ b/src/umka_common.c
@@ -528,10 +528,10 @@ void blocksInit(Blocks *blocks, Error *error)
 
 void blocksEnterFn(Blocks *blocks, const struct tagIdent *fn, bool hasUpvalues)
 {
+    blocks->top++;
     if (blocks->top >= MAX_BLOCK_NESTING)
         blocks->error->handler(blocks->error->context, "Block nesting is too deep");
 
-    blocks->top++;
     blocks->item[blocks->top].block = blocks->numBlocks++;
     blocks->item[blocks->top].fn = fn;
     blocks->item[blocks->top].localVarSize = 0;

--- a/src/umka_common.h
+++ b/src/umka_common.h
@@ -13,7 +13,7 @@ enum
 {
     DEFAULT_STR_LEN     = 255,
     MAX_IDENT_LEN       = DEFAULT_STR_LEN,
-    MAX_IDENTS_IN_LIST  = 256,
+    MAX_IDENTS_IN_LIST  = 16,
     MAX_MODULES         = 1024,
     MAX_PARAMS          = 16,
     MAX_BLOCK_NESTING   = 100,

--- a/src/umka_types.c
+++ b/src/umka_types.c
@@ -718,7 +718,7 @@ const Param *typeAddParam(const Types *types, Signature *sig, const Type *type, 
     if (typeFindParam(sig, name))
         types->error->handler(types->error->context, "Duplicate parameter %s", name);
 
-    if (sig->numParams > MAX_PARAMS)
+    if (sig->numParams >= MAX_PARAMS)
         types->error->handler(types->error->context, "Too many parameters");
 
     Param *param = storageAdd(types->storage, sizeof(Param));


### PR DESCRIPTION
Here are the examples:
https://gist.github.com/ske2004/e9392d8b784cfbf447c3f646daa1a442

This fixes 2 bounds checks but also limits ident list size to 16 entries to reduce stack overflows. Parsing one ident list takes 65535 bytes. I found this when testing Umka with devkitPro which has a 65535 bytes stack size by default, so it overflowed by creating just one variable.

(I set to 16 because I feel it makes sense to match max arg count)