### PR TITLE
improve 3dcam build script for linux

### DIFF
--- a/examples/3dcam/build_3dcam_linux.sh
+++ b/examples/3dcam/build_3dcam_linux.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-cp ../../libumka.so .
 cp ../../umka_api.h .
+cp ../../libumka.so .
+if [ $? -ne 0 ]; then
+    echo "Use build_linux.sh in the root umka directory,"
+    echo "then run the example in the created umka_linux directory."
+    return 1
+fi
 
-gcc 3dcam.c -o 3dcam -lumka -lraylib -L$PWD -Wl,-rpath,'$ORIGIN'
+gcc 3dcam.c -o 3dcam -lumka -lraylib -L$PWD -lm -Wl,-rpath,'$ORIGIN'


### PR DESCRIPTION
copied build/src files are in nested directories, plus i needed the math lib to compile, at least based on a recent raylib: 
```
lowagner@log:~/code/umka-lang/examples/3dcam$ ./build_3dcam_linux.sh 
/usr/bin/ld: /usr/local/lib/libraylib.a(rglfw.o): undefined reference to symbol 'round@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
```