### PR TITLE
fix(ident): error on stack frame size overflow (#613)

### DIFF
--- a/src/umka_ident.c
+++ b/src/umka_ident.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #include "umka_ident.h"
 
@@ -321,7 +322,11 @@ int identAllocStack(Idents *idents, const Types *types, Blocks *blocks, const Ty
     if (!localVarSize)
         idents->error->handler(idents->error->context, "Stack frame is not found");
 
-    *localVarSize = align(*localVarSize + typeSize(types, type), typeAlignment(types, type));
+    const int size = typeSize(types, type);
+    if (size > INT_MAX - *localVarSize)
+        idents->error->handler(idents->error->context, "Stack frame is too large");
+
+    *localVarSize = align(*localVarSize + size, typeAlignment(types, type));
     return -2 * sizeof(Slot) - (*localVarSize);  // 2 extra slots for the stack frame ref count and parameter layout table
 }
 


### PR DESCRIPTION
Fixes #613.

Variadic parameter packing builds a static array on the stack. When the element type is huge (the repro uses a 1 GB struct), the array size in `identAllocStack` overflows the `int localVarSize`. The wrapped value flows into `doEnterFrame` as `localVarSlots`, and the existing stack overflow check (`fiber->top - localVarSlots - fiber->stack < MEM_MIN_FREE_STACK`) is bypassed because the wrap makes the pointer arithmetic give a large positive ptrdiff. The subsequent `memset(fiber->top, 0, localVarSlots * sizeof(Slot))` segfaults.

Catch it at compile time: if adding the new local would overflow `INT_MAX`, raise "Stack frame is too large", same shape as the existing "Array is too large" / "Structure is too large" checks.

Repro from the issue (`umka repro.um`):
```
type T = struct { x: [1_000_000_000]uint8 }
fn foo(a: ..T) { printf("len = %d\n", len(a)) }
fn main() { foo({}, {}) }
```

Before: SEGV in `__bzero` from `doEnterFrame`.
After: `Error repro.um (10, 15): Stack frame is too large`.

Verified `./test_linux.sh` (full `tests/all.um` suite) produces identical output before and after the change.